### PR TITLE
Adds Support for Importing GPG Keys

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,12 @@ redis_bind_address: "127.0.0.1"
 redis_backup_enabled: yes
 redis_backup_schedule: "0 19 * * *"
 redis_backup_target: "file:///backups/redis"
+redis_backup_import_gpg_keys: false
+redis_backup_system_user: "root"
+redis_backup_system_group: "root"
+redis_backup_gpg_private_key:
+redis_backup_gpg_public_key:
+redis_backup_gpg_trust_file:
 redis_backup_gpg_key: disabled
 redis_backup_gpg_pw: ""
 redis_backup_gpg_opts: ''

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,19 @@ dependencies:
     redis_bind: "{{ redis_bind_address }}"
     tags:
       - redis
+
+  - role: onaio.gpg-import
+    vars:
+      gpg_user: "{{ redis_backup_system_user }}"
+      gpg_group: "{{ redis_backup_system_group }}"
+      gpg_private_key: "{{ redis_backup_gpg_private_key }}"
+      gpg_public_key: "{{ redis_backup_gpg_public_key }}"
+      gpg_trust_file: "{{ redis_backup_gpg_trust_file }}"
+    when: redis_backup_enabled == true and redis_backup_import_gpg_keys == true
+    tags:
+      - backup
+      - gpg-import
+
   - role: Stouts.backup
     become: true
     become_user: "root"


### PR DESCRIPTION
Since, in some cases, the Redis backups might have to be encrypted, add
support for importing GPG keys from exported files.

Signed-off-by: Jason Rogena <jason@rogena.me>