### PR TITLE
Skip stouts.backup Role When Backup is Disabled

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,3 +23,4 @@ dependencies:
     backup_full_max_age: "{{ redis_backup_full_max_age }}"
     tags:
       - backup
+    when: redis_backup_enabled


### PR DESCRIPTION
Only run stouts.backup role when Redis backup is enabled.